### PR TITLE
Add jquery import to widget_dragdrop.ts

### DIFF
--- a/packages/controls/src/widget_dragdrop.ts
+++ b/packages/controls/src/widget_dragdrop.ts
@@ -9,6 +9,8 @@ import {
     DOMWidgetView, unpack_models, WidgetModel, WidgetView, JupyterLuminoPanelWidget, reject
 } from '@jupyter-widgets/base';
 
+import $ from 'jquery';
+
 export
 class DraggableBoxModel extends CoreDOMWidgetModel {
     defaults(): Backbone.ObjectHash {


### PR DESCRIPTION
To fix the following, so the drag and drop widgets also work in JupyterLab:

![drag-drop-jquery](https://user-images.githubusercontent.com/591645/72663553-3a3b7500-39f4-11ea-990f-ba8260ec98e5.gif)

This follows the same approach as for the other widgets ([controller](https://github.com/jupyter-widgets/ipywidgets/blob/7cb20cdf2df8ad54fbc0897934b3075998a9a9b5/packages/controls/src/widget_controller.ts#L21), int, box...).

The reason it works in classic notebook is that jquery is already available on the page.